### PR TITLE
do not show a link if no job_url is given

### DIFF
--- a/jobtracker/jobapps/templates/jobapps/jobapp_page.html
+++ b/jobtracker/jobapps/templates/jobapps/jobapp_page.html
@@ -101,10 +101,14 @@ Job Lizard - {{ jobapp.company }}
             {{ jobapp.job_source }}
         </div>
         <div class="col-5 text-start">
+            {% if jobapp.job_url == "" %}
+            <p>None</p>
+            {% else %}
             <a class="link-success link-offset-1 link-underline-opacity-50"
                href="{{ jobapp.job_url }}" target="_blank">
                 {{ jobapp.title }} - {{ jobapp.company }}
             </a>
+            {% endif %}
         </div>
     </div>
     <div class="row mb-4">


### PR DESCRIPTION
If a `job_url` exists, show link to that url
otherwise, show `None` to indicate that it was not added to the record